### PR TITLE
Alinear Dockerfile y Docker Compose para iniciar con Gunicorn

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,4 @@ ENV FLASK_APP=run.py
 # Exponer el puerto de Flask
 EXPOSE 5000
 
-# CMD ["flask", "run", "--host=0.0.0.0"]
+CMD ["gunicorn", "--bind", "0.0.0.0:5000", "run:app"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       options:
         max-size: "500m"
         max-file: "2"
-    command: flask run --host=0.0.0.0
+    command: gunicorn --bind 0.0.0.0:5000 run:app
     volumes:
       - ./:/app
     ports:

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ Flask-SQLAlchemy==3.1.1
 google-auth==2.40.3
 google-genai==1.19.0
 greenlet==3.2.2
+gunicorn==23.0.0
 h11==0.16.0
 httpcore==1.0.9
 httpx==0.28.1


### PR DESCRIPTION
### Motivation
- Alinear el comportamiento de la imagen con el servicio definido en `docker-compose.yml` para usar un servidor WSGI de producción en lugar del servidor de desarrollo de Flask.
- Garantizar que la imagen arranque con Gunicorn por defecto para despliegues y ejecuciones locales sin override.

### Description
- Se actualizó el `Dockerfile` para usar `CMD ["gunicorn", "--bind", "0.0.0.0:5000", "run:app"]` en lugar del comando de desarrollo de Flask.
- Se añadió `gunicorn==23.0.0` a `requirements.txt` y se dejó el servicio `app` en `docker-compose.yml` usando `command: gunicorn --bind 0.0.0.0:5000 run:app`.
- Se mantuvo la exposición del puerto `5000` y la instalación de dependencias tal como estaba en la imagen base.

### Testing
- Se ejecutó `pytest -q` y la suite devolvió `6 passed, 1 failed`, con el fallo en `tests/test_books.py::test_get_recommendations` causado por la ausencia de la variable de entorno `GEMINI_API_KEY`.
- Se intentó validar la configuración de compose con `docker compose config`, pero la comprobación falló porque el binario `docker` no está instalado en este entorno.
- La falla reportada es preexistente y no está relacionada con el cambio para arrancar la app con Gunicorn.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cc1115cac832394eea52448ea33d6)